### PR TITLE
CI: restore missing env variable for anaconda upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 sudo: false
 
+env:
+  global:
+    - OFFICIAL_REPO="pcdshub/pswalker"
+
 matrix:
   include:
      - python: 3.6


### PR DESCRIPTION
I made a mistake, so this won't end up in our channels. I hope I don't have to do too many more of these CI fixes.