### PR TITLE
MNT: make tests compatible with ophyd 1.4

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
 
     run:
       - python {{PY_VER}}*,>=3
-      - ophyd >=1.2.0
+      - ophyd 1.4.0rc4|>=1.4.0
       - bluesky >=1.0.0
       - pcdsdevices >=0.8.0
       - simplejson

--- a/pswalker/sim/areadetector/base.py
+++ b/pswalker/sim/areadetector/base.py
@@ -10,5 +10,5 @@ def ad_group(cls, attr_suffix, **kwargs):
     """
     defn = OrderedDict()
     for attr in attr_suffix:
-        defn[attr] = (cls, kwargs)
+        defn[attr] = (cls, '', kwargs)
     return defn

--- a/pswalker/sim/areadetector/plugins.py
+++ b/pswalker/sim/areadetector/plugins.py
@@ -58,7 +58,7 @@ class PluginBase(plugins.PluginBase):
     unique_id = Component(FakeSignal, value=0)
 
 
-class StatsPlugin(plugins.StatsPlugin, PluginBase):
+class StatsPlugin(PluginBase, plugins.StatsPlugin):
     """
     StatsPlugin but with components instantiated to be empty signals.
 
@@ -252,7 +252,7 @@ class StatsPlugin(plugins.StatsPlugin, PluginBase):
     def noise_kwargs_y(self, val):
         self.centroid.y.noise_kwargs = val
 
-class ImagePlugin(plugins.ImagePlugin, PluginBase):
+class ImagePlugin(PluginBase, plugins.ImagePlugin):
     """
     Image plugin with a couple of the signals spoofed.
 
@@ -261,6 +261,7 @@ class ImagePlugin(plugins.ImagePlugin, PluginBase):
     """
     plugin_type = Component(FakeSignal, value="NDPluginStdArrays")
     array_data = Component(FakeSignal, value=np.zeros((256,256)))
+    shaped_image = array_data
 
     def __init__(self, prefix, *args, **kwargs):
         super().__init__(prefix, *args, **kwargs)

--- a/pswalker/sim/signal.py
+++ b/pswalker/sim/signal.py
@@ -18,7 +18,7 @@ class FakeSignal(Signal):
     velocity parameter, and setting the value of the signal according to an
     outside function/method.
     """
-    def __init__(self, value=0, put_sleep=0, get_sleep=0, 
+    def __init__(self, prefix='', value=0, put_sleep=0, get_sleep=0,
                  noise=False, noise_type="norm", noise_func=None, noise_args=(), 
                  noise_kwargs={}, velocity=None, use_string=False, **kwargs):
         self.put_sleep = put_sleep


### PR DESCRIPTION
Keeping our environment clean by making this package test correctly with the upcoming ophyd release. PCDS is going to be using ophyd 1.4.0rc4 soon so every package with ophyd imports may need small tweaks.