### PR TITLE
CI: build with the desired python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Test conda build
-  - conda build -q conda-recipe --output-folder bld-dir
+  - conda build -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
   - conda config --add channels "file://`pwd`/bld-dir"
   # Create test environment
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pswalker --file dev-requirements.txt


### PR DESCRIPTION
Default version changed from 3.6 to 3.7 at some point. We should have always specified the python version.