### PR TITLE
MNT: remove codecov after security breach

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,6 @@ PSWALKER
 .. image:: https://travis-ci.org/slaclab/pswalker.svg?branch=master
     :target: https://travis-ci.org/slaclab/pswalker
 
-.. image:: https://codecov.io/gh/slaclab/pswalker/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/slaclab/pswalker
-
 .. image:: https://landscape.io/github/slaclab/pswalker/master/landscape.svg?style=flat
    :target: https://landscape.io/github/slaclab/pswalker/master
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,1 @@
 pytest
-codecov


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove codecov. We aren't using it and they had a security breach