### PR TITLE
MAINT: fix deprecated import

### DIFF
--- a/pswalker/plans.py
+++ b/pswalker/plans.py
@@ -7,7 +7,7 @@ Bluesky Plans for the Walker
 import time
 import itertools
 import logging
-from collections import Iterable
+from collections.abc import Iterable
 from copy import copy
 ###############
 # Third Party #

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ simplejson
 lmfit
 numpy
 pandas
+pcdsdevices


### PR DESCRIPTION
This was confusingly already fixed elsewhere in the repo.

This import was deprecated in Python a long time ago and officially moved in Python 3.10.

This makes this package importable on python>=3.10. I made a python 3.10 environment and it passes the tests after this commit.