### PR TITLE
BLD: use bluesky-base for conda builds

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   run:
     - python >=3.6
     - ophyd >=1.5.0
-    - bluesky >=1.5.0
+    - bluesky-base >=1.5.0
     - pcdsdevices >=2.6.0
     - simplejson
     - lmfit


### PR DESCRIPTION
Use bluesky base in conda builds, try to avoid pulling matplotlib and with it qt6