### PR TITLE
MAINT: also use matplotlib-base over matplotlib as a dep

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - lmfit
     - numpy
     - pandas
-    - matplotlib
+    - matplotlib-base
     - jinja2
 
 test:


### PR DESCRIPTION
This repo actually had both non-base issues